### PR TITLE
Forum topic can now be marked as read manually or automatically.

### DIFF
--- a/app/src/main/java/nl/uscki/appcki/android/fragments/forum/adapter/ForumPostAdapter.java
+++ b/app/src/main/java/nl/uscki/appcki/android/fragments/forum/adapter/ForumPostAdapter.java
@@ -83,6 +83,10 @@ public class ForumPostAdapter extends BaseItemAdapter<ForumPostAdapter.ForumPost
             this.signature = itemView.findViewById(R.id.forum_post_signature);
         }
 
+        public Post getPost() {
+            return post;
+        }
+
         public void populateFromPost(Post post) {
             this.post = post;
             Context c = itemView.getContext();
@@ -154,6 +158,23 @@ public class ForumPostAdapter extends BaseItemAdapter<ForumPostAdapter.ForumPost
                 notificationDot.setVisibility(View.GONE);
             } else {
                 notificationDot.setVisibility(View.VISIBLE);
+            }
+        }
+
+        public void updateRead(boolean tentative) {
+            int visibility;
+            if(topic == null || topic.isRead(post)) {
+                visibility = View.GONE;
+            } else {
+                visibility = View.VISIBLE;
+            }
+
+            if(visibility != notificationDot.getVisibility()) {
+                notificationDot.animate()
+                        .alpha(visibility == View.GONE ? tentative ? 0.3f : 0.0f : 1.0f)
+                        .withEndAction(() -> {
+                            if(!tentative) notificationDot.setVisibility(visibility);
+                        });
             }
         }
 

--- a/app/src/main/java/nl/uscki/appcki/android/generated/forum/Topic.java
+++ b/app/src/main/java/nl/uscki/appcki/android/generated/forum/Topic.java
@@ -65,11 +65,11 @@ public class Topic implements IWilsonBaseItem, Parcelable {
     };
 
     public boolean isRead() {
-        return lastPost == null || lastRead == null || lastPost.getOriginal_post_time().isBefore(lastRead.getPost_time()) || lastPost.getOriginal_post_time().equals(lastRead.getPost_time());
+        return lastPost == null || (lastRead != null && (lastPost.getOriginal_post_time().isBefore(lastRead.getPost_time()) || lastPost.getOriginal_post_time().equals(lastRead.getPost_time())));
     }
 
     public boolean isRead(Post post) {
-        return lastRead == null || post.getPost_time().isBefore(lastRead.getOriginal_post_time()) || post.getPost_time().equals(lastRead.getOriginal_post_time());
+        return lastRead != null && (post.getPost_time().isBefore(lastRead.getOriginal_post_time()) || post.getPost_time().equals(lastRead.getOriginal_post_time()));
     }
 
     @Override
@@ -108,6 +108,15 @@ public class Topic implements IWilsonBaseItem, Parcelable {
 
     public Post getLastPost() {
         return lastPost;
+    }
+
+    /**
+     * WARNING: This call only changes the object temporarily until the next API refresh.
+     * To make the last read post persistent, make sure to use the ForumAPI.
+     * @param lastRead  Last read post
+     */
+    public void setLastRead(Post lastRead) {
+        this.lastRead = lastRead;
     }
 
     @Override

--- a/app/src/main/res/menu/forum_posts_sort_menu.xml
+++ b/app/src/main/res/menu/forum_posts_sort_menu.xml
@@ -23,4 +23,9 @@
         android:title="@string/app_general_action_share"
         android:icon="@drawable/ic_share_white_24dp"
         app:showAsAction="ifRoom"/>
+    <item
+        android:id="@+id/forum_post_mark_topic_as_read"
+        android:title="@string/wilson_media_forum_topic_mark_as_read"
+        app:showAsAction="never"
+        />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,6 +438,8 @@
     <string name="wilson_media_forum_topic_created_date">Aangemaakt op %s</string>
     <string name="wilson_media_forum_post_edited_info">Laatste wijziging op %s</string>
     <string name="wilson_media_forum_recent_post_author_and_forum">%s @ %s</string>
+    <string name="wilson_media_forum_topic_mark_as_read">Markeren als gelezen</string>
+
 
     <string name="wilson_media_forum_sort_desc">Meeste views</string>
     <string name="wilson_media_forum_asc">Minste views</string>


### PR DESCRIPTION
Automatic marking as read only happens if the first to last unread
posts subsequently have been fully in view for at leats 1.5 seconds.

I created this because I thought the API allowed setting mark read on
a per post basis, but this can only be done for the whole topic. But
I was not going to throw away that work :)